### PR TITLE
<fix>Update docker.mdx

### DIFF
--- a/content/docs/core/docker.mdx
+++ b/content/docs/core/docker.mdx
@@ -57,7 +57,7 @@ wget https://fastly.jsdelivr.net/gh/mx-space/core@master/docker-compose.yml
 
 ### 配置 Core 启动配置文件
 
-在下方的表格里填入你的配置，然后点击复制，覆盖 `docker-compose.yml` 里 `environment` 字段对应部分的内容，调整细节使其符合 yaml 语法，保存即可。
+在下方的表格里填入你的配置，然后点击复制，在 `docker-compose.yml` 里 `environment` 字段对应部分的内容后加入，调整细节使其符合 yaml 语法，保存即可。
 
 <Callout type="info">
 鼠标悬停在下方的表格中，可以查看对应的配置项名字。


### PR DESCRIPTION
修复可能误导新手 ~~（我）~~ 的错误（费了一晚上）

此处应为在后补充而非替换（话说用env不是也行嘛）

如果是覆盖则回出现无限循环:

```
Starting Mix Space
============== Configurations ==============
Listen Port: 2333
MongoDB: mongodb://127.0.0.1:27017/mx-space
Redis: 127.0.0.1:6379
Allowed Origins: blog.alan-ztr.eu.org
Config Path: NULL
Encryption: false
Cluster: false
CF Zero Trust Token: 
============================================

[Nest] 1  - 01/19/2025, 8:09:07 PM     LOG 数据目录已经建好：/root/.mx-space
[Nest] 1  - 01/19/2025, 8:09:07 PM     LOG 临时目录已经建好：/tmp/mx-space
[Nest] 1  - 01/19/2025, 8:09:07 PM     LOG 日志目录已经建好：/root/.mx-space/log
[Nest] 1  - 01/19/2025, 8:09:07 PM     LOG 资源目录已经建好：/root/.mx-space/assets
[Nest] 1  - 01/19/2025, 8:09:07 PM     LOG 文件存放目录已经建好：/root/.mx-space/static
[Nest] 1  - 01/19/2025, 8:09:07 PM     LOG 文件回收站目录已经建好：/tmp/mx-space/trash

 ERROR  [ioredis] Unhandled error event: Error: connect ECONNREFUSED 127.0.0.1:6379
    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1634:16)
    at TCPConnectWrap.callbackTrampoline (node:internal/async_hooks:130:17)


 ERROR  [ioredis] Unhandled error event: Error: connect ECONNREFUSED 127.0.0.1:6379
    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1634:16)
    at TCPConnectWrap.callbackTrampoline (node:internal/async_hooks:130:17)

```