### PR TITLE
docs: 2026部署教程

### DIFF
--- a/content/docs/core/community.mdx
+++ b/content/docs/core/community.mdx
@@ -3,10 +3,12 @@ title: 社区分享
 description: 社区用户分享的部署方式
 icon: Share2
 ---
-import { FileText, Video } from 'lucide-react'
+
+import { FileText, Video } from "lucide-react";
 
 <Callout type="info">
-你可以参考他们的部署方式，但我们不保证它们的可用性。如果你也有教程想要与大家分享的话，欢迎您向文档提交 [Pull Request](https://github.com/mx-space/docs/pulls) 以分享您的部署方式。
+  你可以参考他们的部署方式，但我们不保证它们的可用性。如果你也有教程想要与大家分享的话，欢迎您向文档提交
+  [Pull Request](https://github.com/mx-space/docs/pulls) 以分享您的部署方式。
 </Callout>
 
 <Cards num={3}>
@@ -17,69 +19,105 @@ import { FileText, Video } from 'lucide-react'
   href="https://www.miaoer.net/posts/blog/mx-kami-serverless"
   icon={<FileText />}
   target="_blank"
-> Kami 前端部署博文教程 | By 喵二 | 平台：Serverless</Card>
+>
+  {" "}
+  Kami 前端部署博文教程 | By 喵二 | 平台：Serverless
+</Card>
 
 <Card
   title="mx-space + Shiro：如纸一般纯净的新博客"
   href="https://arthals.ink/posts/web/shiro"
   icon={<FileText />}
   target="_blank"
-> 前后端部署博文教程 | By Arthals | 平台：Selfhost</Card>
+>
+  {" "}
+  前后端部署博文教程 | By Arthals | 平台：Selfhost
+</Card>
 
 <Card
   title="使用 Mix Space × Zeabur 搭建自己的个人空间"
   href="https://lab.gb0.dev/post/mxspace-on-zeabur/"
   icon={<FileText />}
   target="_blank"
->前后端部署博文教程 | By 草方块 | 平台：Serverless</Card>
+>
+  前后端部署博文教程 | By 草方块 | 平台：Serverless
+</Card>
 
 <Card
   title="使用 Termux 搭建 Mix-Space"
   href="https://www.rinne.in/posts/default/deploy-mxspace-with-termux"
   icon={<FileText />}
   target="_blank"
->前后端部署博文教程 | By Rinne | 平台：Android</Card>
+>
+  前后端部署博文教程 | By Rinne | 平台：Android
+</Card>
 
 <Card
   title="从 WordPress 迁移数据到 Mix Space"
   href="https://blog.fosky.top/2024/10/09/wordpress-to-mix-space.html"
   icon={<FileText />}
   target="_blank"
->后端迁移系统数据博文教程 | By Fosky</Card>
+>
+  后端迁移系统数据博文教程 | By Fosky
+</Card>
 
 <Card
   title="Shiro 部署如此简单？！"
   href="https://blog.yoruzzz.cn/posts/%E5%BB%BA%E7%AB%99/shiro"
   icon={<FileText />}
   target="_blank"
->前后端部署博文教程 | By 南栀 | 平台：Selfhost </Card>
+>
+  前后端部署博文教程 | By 南栀 | 平台：Selfhost{" "}
+</Card>
 
 <Card
   title="Mx Space + Shiro + Nginx Proxy Manager反向代理部署"
   href="https://zinzin.cc/posts/default/mxspace-shiro"
   icon={<FileText />}
   target="_blank"
-> 前后端部署博文教程 | By 光合作用の少女 | 平台：Selfhost</Card>
+>
+  {" "}
+  前后端部署博文教程 | By 光合作用の少女 | 平台：Selfhost
+</Card>
 
 <Card
   title="使用 1Panel 部署 Mix-Space 和前端 Shiro 主题"
   href="https://blog.lolita.best/posts/blog/MxspaceDeployShiro"
   icon={<FileText />}
   target="_blank"
-> 前后端部署博文教程 | By 星野纯夏 | 平台：Selfhost</Card>
+>
+  {" "}
+  前后端部署博文教程 | By 星野纯夏 | 平台：Selfhost
+</Card>
 
 <Card
   title="使用Claw Cloud Run低成本拥有自己的Shiro"
   href="https://mahiru.tech/posts/default/02"
   icon={<FileText />}
   target="_blank"
-> 前后端部署博文教程 | By 白熊sama | 平台：Serverless</Card>
+>
+  {" "}
+  前后端部署博文教程 | By 白熊sama | 平台：Serverless
+</Card>
 
 <Card
   title="使用NorthFlank低成本部署MixSpace"
   href="https://space.hanze.icu/posts/project/mx"
   icon={<FileText />}
   target="_blank"
-> 前后端部署博文教程 | By C_Hanze | 平台：Serverless</Card>
+>
+  {" "}
+  前后端部署博文教程 | By C_Hanze | 平台：Serverless
+</Card>
+
+<Card
+  title="2026年通过GitHub aciton部署Mix-Space博客和Yohaku主题"
+  href="https://yuuki.diy/posts/tech/blogbuild"
+  icon={<FileText />}
+  target="_blank"
+>
+  {" "}
+  前后端部署博文教程 | By Yuuki | 平台：Serverless
+</Card>
 
 </Cards>

--- a/content/docs/core/community.mdx
+++ b/content/docs/core/community.mdx
@@ -117,7 +117,7 @@ import { FileText, Video } from "lucide-react";
   target="_blank"
 >
   {" "}
-  前后端部署博文教程 | By Yuuki | 平台：Serverless
+  前后端部署博文教程 | By Yuuki | 平台：Selfhost
 </Card>
 
 </Cards>


### PR DESCRIPTION

-->
### Description
之前关注过Innei开发的极简博客主题Shiro
，于是想赞助闭源版本，后面发现重构了主题，更名为Yohaku，更好看了，但是之前的GitHub aciton工作流还是根据Shiro来部署的，出现了一点问题 ，因此折腾了一下用GitHub aciton成功部署，希望能帮助到同样想要部署的大家。 
 