### PR TITLE
docs: add community guide and Yohaku config reference

### DIFF
--- a/content/docs/themes/community.mdx
+++ b/content/docs/themes/community.mdx
@@ -16,3 +16,12 @@ import { FileText } from 'lucide-react'
   target="_blank"
 >前端部署方式拓展博文教程 | By Mikuの鬆 </Card>
 </Cards>
+
+<Cards>
+<Card
+  title="GitHub Actions 构建 Yohaku 的 Docker 镜像"
+  href="https://zwh.moe/posts/technology/yohaku-docker-deployment"
+  icon={<FileText />}
+  target="_blank"
+>前端部署方式拓展博文教程 | By wuhang2003 </Card>
+</Cards>

--- a/content/docs/themes/shiro/deploy.mdx
+++ b/content/docs/themes/shiro/deploy.mdx
@@ -229,6 +229,9 @@ export function FAQBox({ title, children }) {
       },
       "bilibili": {
         "liveId": 1434499
+      },
+      "rss": {
+        "noRSS": true
       }
     }
   }

--- a/content/docs/themes/yohaku/config.mdx
+++ b/content/docs/themes/yohaku/config.mdx
@@ -6,7 +6,7 @@ icon: Bolt
 
 # 配置项
 
-Yohaku 的配置沿用 Shiro 的配置体系，在 Mix Space 后台「配置与云函数」页面中，创建一条 `theme` 引用、名称为 `shiro` 的配置项（数据类型 JSON 或 YAML）。
+Yohaku 的配置沿用 Shiro 的配置体系，在 Mix Space 后台「配置与云函数」页面中，创建一条 `theme` 引用、名称为 `shiro` 的配置项（数据类型 JSON 或 YAML）。配置参考详见 [Shiro 的部署页面](https://mx-space.js.org/docs/themes/shiro/deploy#设置主题配置)。
 
 <Callout type="info">
   Yohaku 复用了 `shiro` 这个配置键名，如果你从 Shiro 迁移到 Yohaku，无需更改配置名称。


### PR DESCRIPTION
- 增加使用 Actions 构建 Yohaku 镜像并进行部署的教程
- 在 Yohaku 的配置介绍页面增加了参考配置示例的链接
- 在默认配置增加 `noRSS` 的配置以避免无法访问 RSS（相关 issues：https://github.com/innei-dev/Yohaku/issues/116 ）